### PR TITLE
Fix for browsing in new tab/window

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ A Chrome extension that removes locale/language from the URL to navigate to the 
 - GitHub Documentation  
   i.e. `https://docs.github.com/<LANGUAGE>/...`
 
+### Requirements for supported Websites
+
+  1. The URL of each page of the websites  includes locale/language information as a part of the path or one of the query parameters.
+  1. The websites can redirect to the each user's default language page if the URL doesn't include the locale/language information 
+
 ## Installation
 
 <!--
@@ -74,6 +79,15 @@ This extension can be installed from [Chrome Web Store](https://chromewebstore.g
    - Open the Debug panel.
    - Select "Launch Chrome" or "Launch Edge".
    - Click the green play button to start debugging.
+
+## Change logs
+
+### [0.0.2](https://github.com/horihiro/Navigation-to-your-language-ChromeExtension/releases/tag/0.0.2)
+Bug fix
+  - Cannot redirect when opening on new tab/window [#1](https://github.com/horihiro/Navigation-to-your-language-ChromeExtension/issues/1)
+
+### [0.0.1](https://github.com/horihiro/Navigation-to-your-language-ChromeExtension/releases/tag/0.0.1)
+The First release
 
 ## License
 MIT © horihiro

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -44,7 +44,7 @@ chrome.webNavigation.onBeforeNavigate.addListener(async (details) => {
 
 chrome.webNavigation.onCommitted.addListener(async (details) => {
   const urls = urlMap.get(details.tabId);
-  if (!urls?.from) return;
+  if (urls?.from == null) return;
   urlMap.set(details.tabId, null);
 
   const pattern = targetUrlPatterns.find(p => details.url.match(p));


### PR DESCRIPTION
Fix the issue that the extension doesn't work on clicking `a` tag with `target="_blank"` (i.e. closing #1).