### PR TITLE
Enhance toast notification with fade-out animation and refactor style…

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ This extension can be installed from [Chrome Web Store](https://chromewebstore.g
 
 ## Change logs
 
+### [0.0.4](https://github.com/horihiro/Navigation-to-your-language-ChromeExtension/releases/tag/0.0.4)
+Improve Feature(s)
+  - Keep a toast showing until clicking [#9](https://github.com/horihiro/Navigation-to-your-language-ChromeExtension/pull/9)
+
 ### [0.0.3](https://github.com/horihiro/Navigation-to-your-language-ChromeExtension/releases/tag/0.0.3)
 Add Feature(s)
   - Add exclution path pattern [#5](https://github.com/horihiro/Navigation-to-your-language-ChromeExtension/pull/5)

--- a/src/content/main.ts
+++ b/src/content/main.ts
@@ -6,26 +6,42 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
   if (!originalUrl) return;
   // show toast message that will fade out after 10 seconds
   const toast = document.createElement('div');
-  toast.style.cssText = `
-    cursor: pointer;
-    position: fixed;
-    bottom: 10px;
-    left: 10px;
-    background-color: #333;
-    color: white;
-    padding: 10px;
-    border-radius: 5px;
-    z-index: 10001;
-  `;
+  toast.style.cursor = 'pointer';
+  toast.style.position = 'fixed';
+  toast.style.bottom = '10px';
+  toast.style.left = '10px';
+  toast.style.backgroundColor = '#333';
+  toast.style.color = 'white';
+  toast.style.padding = '10px';
+  toast.style.borderRadius = '5px';
+  toast.style.zIndex = '10001';
+  toast.style.animationDuration = '1s';
   toast.innerHTML = `Click this to go to the original locale page.`;
+  const style = document.createElement('style');
+  style.innerHTML = `
+.nav2yourlocale-fadeOut {
+  animation-name: fadeOut;
+}
+@keyframes fadeOut {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+`;
+  toast.appendChild(style);
   toast.addEventListener('click', () => {
     window.location.href = originalUrl;
   });
+  document.body.addEventListener('click', () => {
+    toast.classList.add('nav2yourlocale-fadeOut');
+  });
+  toast.addEventListener('animationend', () => {
+    toast.remove();
+  });
   document.body.appendChild(toast);
-  await sleep(5000);
-  // toast.style.cssText += `      animation: fadeOut 2s forwards;`;
-  // await sleep(2000);
-  toast.remove();
 })();
 
 chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to document the latest release and improvements to the toast notification feature in the `src/content/main.ts` file.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R84-R87): Added changelog entry for version 0.0.4, which includes an improvement to keep a toast showing until it is clicked.

Toast notification improvements:

* [`src/content/main.ts`](diffhunk://#diff-e63bd80c4669965c18d2c9210df59221bd89ba02bf3f9d7d3759098ab6323eaeL9-R44): Refactored the toast styling code to use individual style properties instead of a single `cssText` string, and added an animation for fading out the toast when it is clicked.… assignment