### PR TITLE
improve event handling order in service worker

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -130,9 +130,7 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
     const urls = urlMap.get(sender.tab.id);
     if (urls?.original === sender.url) return;
     sendResponse(urls?.original);
-    console.log(`onMessage: ${Date.now()}`)
     urlMap.set(sender.tab.id, null);
-    console.log(`----`)
   } else if (request.type === contextMenus[2].id) {
     const { host, pattern } = request;
     const items = await chrome.storage.local.get({ exclusionUrlPatterns: {} });


### PR DESCRIPTION
This pull request introduces several updates to the `src/background/service-worker.ts` file, focusing on improving error handling, managing URL state during navigation events, and enhancing the visibility logic for context menus. The changes aim to make the service worker more robust and responsive to navigation and context menu updates.

### Error Handling Enhancements:
* Added a `try-catch` block to the `updateContextMenus` function to prevent unhandled exceptions when updating context menus. [[1]](diffhunk://#diff-361112ac0c7f57d52557ff54af1171a4434278993690cf155731a16ce2865098R9) [[2]](diffhunk://#diff-361112ac0c7f57d52557ff54af1171a4434278993690cf155731a16ce2865098R23)

### URL State Management:
* Introduced a `urlMap` to track the processing state of tabs during navigation events. This ensures better coordination between navigation events and subsequent actions.
* Updated the `onBeforeNavigate` listener to set `urlMap` entries to `null` for excluded URLs, improving the handling of navigation events for URLs matching exclusion patterns.
* Added a polling mechanism in the `onCommitted` listener to wait for the processing state of a tab to complete before proceeding, ensuring accurate URL state updates.